### PR TITLE
Enhancements to script and options.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/echoboomer/terraform-buildkite-plugin) ![GitHub Release Date](https://img.shields.io/github/release-date/echoboomer/terraform-buildkite-plugin) ![GitHub contributors](https://img.shields.io/github/contributors/echoboomer/terraform-buildkite-plugin) ![GitHub issues](https://img.shields.io/github/issues/echoboomer/terraform-buildkite-plugin)
 
-Allows running Terraform in a Buildkite pipeline.
+Runs Terraform as a Buildkite pipeline step.
+
+## Disclaimer
+
+This plugin does not claim to solve every problem related to running Terraform in a Buildkite pipeline. It provides a basis for expansion. We have tried to avoid providing so many options that the plugin becomes confusing, but we understand that use cases vary and many people do many different things with their Terraform workflows. If you find that a critical feature is either configured in a way that hinders your process or missing outright, please open an issue or contribute.
 
 ## Prerequisites
+
+The plugin makes a few assumptions about your environment:
 
 #### Organization
 
@@ -22,13 +28,16 @@ If using a Terraform workspace, the plugin will also look for a `.tfvars` file i
 
 If not using a Terraform workspace, the `default` workspace is used.
 
-#### Artifacts
-
-At the end of the Terraform plan, the plugin automatically generates `tfplan` as-is and `tfplan.json` for a JSON formatted version of the output. This is useful if you'd like to use a plugin like [artifacts](https://github.com/buildkite-plugins/artifacts-buildkite-plugin) to move your Terraform plan between steps, which is even more useful if you've opted to make two separate steps with a dedicated `apply` step with `plan` disabled. These files are both available in the `terraform/` directory in the agent for reference. You can also run the JSON output through something like OPA.
-
 #### Agent Requirements
 
 Your Buildkite agents will need Docker.
+
+## Behavior
+
+The plugin does a few things automatically:
+
+- At the end of the Terraform `plan` step, the plugin automatically generates `tfplan.json` for a JSON formatted version of the plan output in the `terraform/` directory. This is useful if you'd like to use a plugin like [artifacts](https://github.com/buildkite-plugins/artifacts-buildkite-plugin) to move your Terraform plan between steps, which is even more useful if you've opted to make two separate steps with a dedicated `apply` step with `plan` disabled. We've provided an example of this below. You can also run the JSON output through something like OPA.
+- At the end of the Terraform `plan` step, the plugin sets the Buildkite meta-data field `tf_diff` to either `true` or `false` based on whether or not there are changes in the plan.
 
 ## Example
 
@@ -38,7 +47,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.0.1:
+      - echoboomer/terraform#v1.2.4:
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
 ```
 
@@ -48,7 +57,7 @@ This is the only required parameter. You can pass in other options to adjust beh
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.0.1:
+      - echoboomer/terraform#v1.2.4:
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           image: myrepo/mycustomtfimage
           version: 0.12.21
@@ -62,11 +71,38 @@ If you want an out of the box solution that simply executes a `plan` on non-mast
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.0.1:
+      - echoboomer/terraform#v1.2.4:
           apply_master: true
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           version: 0.12.21
 ```
+
+This will simply look at `BUILDKITE_BRANCH` and only run the `apply` step if it is set to `master`.
+
+You can also break your Terraform steps into different sections depending on your use case. For example:
+
+```yml
+steps:
+  - label: "terraform plan"
+    branches: "!master"
+    plugins:
+      - echoboomer/terraform#v1.2.4:
+          init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
+          version: 0.12.21
+      - artifacts#v1.2.0:
+          upload: "terraform/tfplan"
+  - label: "terraform apply"
+    branches: "master"
+    plugins:
+      - artifacts#v1.2.0:
+          download: "terraform/tfplan"
+      - echoboomer/terraform#v1.2.4:
+          apply_only: true
+          init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
+          version: 0.12.21
+```
+
+This is useful if you want more control over the behavior of the plugin or if it is necessary to split apart the `apply` step for whatever reason.
 
 ## Configuration
 
@@ -89,6 +125,10 @@ If using a custom Docker image to run `terraform`, set it here. This should only
 ### `init_config` (Required, string)
 
 A string specifying flags to pass to `terraform init`. This is required.
+
+### `skip_apply_no_diff` (Not Required, boolean)
+
+If this is provided and set to `true`, the `apply` step will be skipped if `TF_DIFF` is also `false`. The latter variable is automatically exported during every `plan` step.
 
 ### `use_workspaces` (Not Required, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -49,6 +49,7 @@ function terraform-run() {
   local IMAGE_NAME=${BUILDKITE_PLUGIN_TERRAFORM_IMAGE:-"hashicorp/terraform"}
   local INIT_CONFIG=${BUILDKITE_PLUGIN_TERRAFORM_INIT_CONFIG}
   local USE_WORKSPACES=${BUILDKITE_PLUGIN_TERRAFORM_USE_WORKSPACES:-false}
+  local SKIP_APPLY_NO_DIFF=${BUILDKITE_PLUGIN_TERRAFORM_SKIP_APPLY_NO_DIFF:-false}
   local VERSION=${BUILDKITE_PLUGIN_TERRAFORM_VERSION:-0.13.0}
   local WORKSPACE=${BUILDKITE_PLUGIN_TERRAFORM_WORKSPACE:-default}
 
@@ -69,20 +70,35 @@ function terraform-run() {
 
   if [[ "${APPLY_ONLY}" == false ]]; then
     echo "+++ :terraform: :hourglass: Running Terraform plan..."
+
     if [[ "${USE_WORKSPACES}" == true ]]; then
-      terraform-bin plan -input=false -out tfplan-${WORKSPACE} -var-file="${WORKSPACE}-terraform.tfvars"
-      terraform-bin show -json tfplan-${WORKSPACE} > tfplan-${WORKSPACE}.json
+      terraform-bin plan -input=false -out tfplan -var-file="${WORKSPACE}-terraform.tfvars"
     else
       terraform-bin plan -input=false -out tfplan
-      terraform-bin show -json tfplan > tfplan.json
+    fi
+
+    # Capture plan output for setting variables and passing as artifacts.
+    terraform-bin show tfplan -no-color > tfplan.txt
+    terraform-bin show -json tfplan > tfplan.json
+
+    if grep -iFq "Plan: 0 to add, 0 to change, 0 to destroy." tfplan.txt; then
+      echo ""
+      echo "+++ :terraform: :white_check_mark: Exporting tf_diff=false to agent metadata."
+      buildkite-agent meta-data set "tf_diff" "false"
+      export TF_DIFF=false
+    else
+      echo ""
+      echo "+++ :terraform: :white_check_mark: Exporting tf_diff=true to agent metadata."
+      buildkite-agent meta-data set "tf_diff" "true"
+      export TF_DIFF=true
     fi
   fi
 
-  if [[ "${APPLY}" == true || "${APPLY_ONLY}" == true || ("${APPLY_MASTER}" == true && "${BUILDKITE_BRANCH}" == "master") ]]; then
-    echo "+++ :terraform: :hourglass: Running Terraform apply based on calculated plan..."
-    if [[ "${USE_WORKSPACES}" == true ]]; then
-      terraform-bin apply -input=false tfplan-${WORKSPACE}
-    else
+  if [[ "${TF_DIFF}" == false && "${SKIP_APPLY_NO_DIFF}" == true ]]; then
+    echo "+++ :terraform: :zzz: Skipping apply step."
+  else
+    if [[ "${APPLY}" == true || "${APPLY_ONLY}" == true || ("${APPLY_MASTER}" == true && "${BUILDKITE_BRANCH}" == "master") ]]; then
+      echo "+++ :terraform: :hourglass: Running Terraform apply based on calculated plan..."
       terraform-bin apply -input=false tfplan
     fi
   fi


### PR DESCRIPTION
- Enhances readme with a few more examples.
- Adds sections to readme to clarify how some things work.
- Updates version numbers in readme examples.
- Templates for issues added in last push.
- Removes redundancies in the `command` hook to make things cleaner.
- Export `buildkite-agent meta-data` to make other steps more useful.
- Better output during the Terraform process steps.
- Adds `SKIP_APPLY_NO_DIFF` option.