### PR TITLE
Adds option for no validate, syntax cleanup.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.4:
+      - echoboomer/terraform#v1.2.5:
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
 ```
 
@@ -57,7 +57,7 @@ This is the only required parameter. You can pass in other options to adjust beh
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.4:
+      - echoboomer/terraform#v1.2.5:
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           image: myrepo/mycustomtfimage
           version: 0.12.21
@@ -71,7 +71,7 @@ If you want an out of the box solution that simply executes a `plan` on non-mast
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.4:
+      - echoboomer/terraform#v1.2.5:
           apply_master: true
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           version: 0.12.21
@@ -86,7 +86,7 @@ steps:
   - label: "terraform plan"
     branches: "!master"
     plugins:
-      - echoboomer/terraform#v1.2.4:
+      - echoboomer/terraform#v1.2.5:
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           version: 0.12.21
       - artifacts#v1.2.0:
@@ -96,7 +96,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: "terraform/tfplan"
-      - echoboomer/terraform#v1.2.4:
+      - echoboomer/terraform#v1.2.5:
           apply_only: true
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           version: 0.12.21
@@ -125,6 +125,10 @@ If using a custom Docker image to run `terraform`, set it here. This should only
 ### `init_config` (Required, string)
 
 A string specifying flags to pass to `terraform init`. This is required.
+
+### `no_validate` (Not Required, boolean)
+
+If provided and set to `true`, the `terraform validate` step will be skipped.
 
 ### `skip_apply_no_diff` (Not Required, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -57,7 +57,7 @@ function terraform-run() {
   cd terraform
 
   if [[ "${APPLY_ONLY}" == false ]]; then
-    echo "+++ :terraform: :hourglass: Setting up Terraform environment..."
+    echo "+++ :terraform: :buildkite: :hammer_and_wrench: Setting up Terraform environment..."
     terraform-bin init ${INIT_CONFIG}
     echo ""
   fi
@@ -72,7 +72,7 @@ function terraform-run() {
   fi
 
   if [[ "${APPLY_ONLY}" == false ]]; then
-    echo "+++ :terraform: :hourglass: Running Terraform plan..."
+    echo "+++ :terraform: :buildkite: :hourglass: Running Terraform plan..."
 
     if [[ "${USE_WORKSPACES}" == true ]]; then
       terraform-bin plan -input=false -out tfplan -var-file="${WORKSPACE}-terraform.tfvars"
@@ -86,22 +86,25 @@ function terraform-run() {
 
     if grep -iFq "Plan: 0 to add, 0 to change, 0 to destroy." tfplan.txt; then
       echo ""
-      echo "--- :terraform: :white_check_mark: Exporting tf_diff=false to agent metadata."
+      echo "--- :terraform: :buildkite: :white_check_mark: Exporting tf_diff=false to agent metadata."
       buildkite-agent meta-data set "tf_diff" "false"
       export TF_DIFF=false
     else
       echo ""
-      echo "--- :terraform: :white_check_mark: Exporting tf_diff=true to agent metadata."
+      echo "--- :terraform: :buildkite: :white_check_mark: Exporting tf_diff=true to agent metadata."
       buildkite-agent meta-data set "tf_diff" "true"
       export TF_DIFF=true
     fi
+
+    echo "--- :terraform: :buildkite: :floppy_disk: Listing directory contents for record keeping."
+    ls -al .
   fi
 
   if [[ "${TF_DIFF}" == false && "${SKIP_APPLY_NO_DIFF}" == true ]]; then
-    echo "--- :terraform: :zzz: Skipping apply step."
+    echo "--- :terraform: :buildkite: :zzz: Skipping apply step."
   else
     if [[ "${APPLY}" == true || "${APPLY_ONLY}" == true || ("${APPLY_MASTER}" == true && "${BUILDKITE_BRANCH}" == "master") ]]; then
-      echo "+++ :terraform: :hourglass: Running Terraform apply based on calculated plan..."
+      echo "+++ :terraform: :buildkite: :hourglass: Running Terraform apply based on calculated plan..."
       terraform-bin apply -input=false tfplan
     fi
   fi

--- a/hooks/command
+++ b/hooks/command
@@ -25,7 +25,7 @@ done
 KNOWN_HOSTS_FILE=$(pwd)/known_hosts
 
 if [[ ! -f "$KNOWN_HOSTS_FILE" ]]; then
-    ssh-keyscan github.com >>$KNOWN_HOSTS_FILE
+  ssh-keyscan github.com >> $KNOWN_HOSTS_FILE
 fi
 
 function terraform-bin() {
@@ -48,6 +48,7 @@ function terraform-run() {
   local BUILDKITE_BRANCH=${BUILDKITE_BRANCH:-}
   local IMAGE_NAME=${BUILDKITE_PLUGIN_TERRAFORM_IMAGE:-"hashicorp/terraform"}
   local INIT_CONFIG=${BUILDKITE_PLUGIN_TERRAFORM_INIT_CONFIG}
+  local NO_VALIDATE=${BUILDKITE_PLUGIN_TERRAFORM_NO_VALIDATE:-false}
   local USE_WORKSPACES=${BUILDKITE_PLUGIN_TERRAFORM_USE_WORKSPACES:-false}
   local SKIP_APPLY_NO_DIFF=${BUILDKITE_PLUGIN_TERRAFORM_SKIP_APPLY_NO_DIFF:-false}
   local VERSION=${BUILDKITE_PLUGIN_TERRAFORM_VERSION:-0.13.0}
@@ -66,7 +67,9 @@ function terraform-run() {
     echo ""
   fi
 
-  terraform-bin validate
+  if [[ "${NO_VALIDATE}" == false ]]; then
+    terraform-bin validate
+  fi
 
   if [[ "${APPLY_ONLY}" == false ]]; then
     echo "+++ :terraform: :hourglass: Running Terraform plan..."
@@ -83,19 +86,19 @@ function terraform-run() {
 
     if grep -iFq "Plan: 0 to add, 0 to change, 0 to destroy." tfplan.txt; then
       echo ""
-      echo "+++ :terraform: :white_check_mark: Exporting tf_diff=false to agent metadata."
+      echo "--- :terraform: :white_check_mark: Exporting tf_diff=false to agent metadata."
       buildkite-agent meta-data set "tf_diff" "false"
       export TF_DIFF=false
     else
       echo ""
-      echo "+++ :terraform: :white_check_mark: Exporting tf_diff=true to agent metadata."
+      echo "--- :terraform: :white_check_mark: Exporting tf_diff=true to agent metadata."
       buildkite-agent meta-data set "tf_diff" "true"
       export TF_DIFF=true
     fi
   fi
 
   if [[ "${TF_DIFF}" == false && "${SKIP_APPLY_NO_DIFF}" == true ]]; then
-    echo "+++ :terraform: :zzz: Skipping apply step."
+    echo "--- :terraform: :zzz: Skipping apply step."
   else
     if [[ "${APPLY}" == true || "${APPLY_ONLY}" == true || ("${APPLY_MASTER}" == true && "${BUILDKITE_BRANCH}" == "master") ]]; then
       echo "+++ :terraform: :hourglass: Running Terraform apply based on calculated plan..."

--- a/plugin.yml
+++ b/plugin.yml
@@ -15,6 +15,10 @@ configuration:
       type: string
     init_config:
       type: string
+    no_validate:
+      type: boolean
+    skip_apply_no_diff:
+      type: boolean
     use_workspaces:
       type: boolean
     version:


### PR DESCRIPTION
- Adds option to skip `terraform validate`.
- Bumps example version numbers in readme.
- Adds missing `skip_apply_no_diff` parameter from last merge to `plugin.yml`.
- Some minor fixes to syntax in `command` hook.
- Readability improvements in `command` hook.
- List `terraform/` directory contents at end in collapsed step to help with planning other steps and seeing what output is available after the steps are done.