### PR TITLE
Fixes to interpolation for init_config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.7:
+      - echoboomer/terraform#v1.2.8:
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
 ```
 
@@ -57,7 +57,7 @@ This is the only required parameter. You can pass in other options to adjust beh
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.7:
+      - echoboomer/terraform#v1.2.8:
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           image: myrepo/mycustomtfimage
           version: 0.12.21
@@ -71,7 +71,7 @@ If you want an out of the box solution that simply executes a `plan` on non-mast
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.7:
+      - echoboomer/terraform#v1.2.8:
           apply_master: true
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           version: 0.12.21
@@ -86,7 +86,7 @@ steps:
   - label: "terraform plan"
     branches: "!master"
     plugins:
-      - echoboomer/terraform#v1.2.7:
+      - echoboomer/terraform#v1.2.8:
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           version: 0.12.21
       - artifacts#v1.2.0:
@@ -96,7 +96,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: "tfplan"
-      - echoboomer/terraform#v1.2.7:
+      - echoboomer/terraform#v1.2.8:
           apply_only: true
           init_config: "-input=false -backend-config=bucket=my_gcp_bucket -backend-config=prefix=my-prefix -backend-config=credentials=sa.json"
           version: 0.12.21

--- a/hooks/command
+++ b/hooks/command
@@ -56,11 +56,9 @@ function terraform-run() {
 
   cd terraform
 
-  if [[ "${APPLY_ONLY}" == false ]]; then
-    echo "+++ :terraform: :buildkite: :hammer_and_wrench: Setting up Terraform environment..."
-    terraform-bin init ${INIT_CONFIG}
-    echo ""
-  fi
+  echo "+++ :terraform: :buildkite: :hammer_and_wrench: Setting up Terraform environment..."
+  terraform-bin init "${INIT_CONFIG}"
+  echo ""
 
   if [[ "${USE_WORKSPACES}" == true ]]; then
     terraform-bin workspace select ${WORKSPACE}


### PR DESCRIPTION
Interpolation isn't working properly for `init_config`. We also need to implicitly run `init` regardless of whether or not we've opted to skip `plan`.