### PR TITLE
Parse arguments to init as an array.

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ If using a custom Docker image to run `terraform`, set it here. This should only
 
 ### `init_config` (Required, string)
 
-A string specifying flags to pass to `terraform init`. This is required.
+A string specifying flags to pass to `terraform init`. This is required. This is parsed as an array and then passed into the `init` command to properly pass spaces, quotes, etc.
 
 ### `no_validate` (Not Required, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -47,7 +47,7 @@ function terraform-run() {
   local APPLY_MASTER=${BUILDKITE_PLUGIN_TERRAFORM_APPLY_MASTER:-false}
   local BUILDKITE_BRANCH=${BUILDKITE_BRANCH:-}
   local IMAGE_NAME=${BUILDKITE_PLUGIN_TERRAFORM_IMAGE:-"hashicorp/terraform"}
-  local INIT_CONFIG=${BUILDKITE_PLUGIN_TERRAFORM_INIT_CONFIG}
+  local INIT_CONFIG=("${BUILDKITE_PLUGIN_TERRAFORM_INIT_CONFIG}")
   local NO_VALIDATE=${BUILDKITE_PLUGIN_TERRAFORM_NO_VALIDATE:-false}
   local USE_WORKSPACES=${BUILDKITE_PLUGIN_TERRAFORM_USE_WORKSPACES:-false}
   local SKIP_APPLY_NO_DIFF=${BUILDKITE_PLUGIN_TERRAFORM_SKIP_APPLY_NO_DIFF:-false}
@@ -57,7 +57,7 @@ function terraform-run() {
   cd terraform
 
   echo "+++ :terraform: :buildkite: :hammer_and_wrench: Setting up Terraform environment..."
-  terraform-bin init "${INIT_CONFIG}"
+  terraform-bin init "${INIT_CONFIG[@]}"
   echo ""
 
   if [[ "${USE_WORKSPACES}" == true ]]; then


### PR DESCRIPTION
Parsing for the `init` config is still not working properly. In an effort to fix this, this approach tries using an array.