### PR TITLE
V1.2.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.12:
+      - echoboomer/terraform#v1.2.11:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
 ```
 
@@ -57,7 +57,7 @@ This is the only required parameter. You can pass in other options to adjust beh
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.12:
+      - echoboomer/terraform#v1.2.11:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           image: myrepo/mycustomtfimage
           version: 0.12.21
@@ -71,7 +71,7 @@ If you want an out of the box solution that simply executes a `plan` on non-mast
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.12:
+      - echoboomer/terraform#v1.2.11:
           apply_master: true
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
@@ -86,7 +86,7 @@ steps:
   - label: "terraform plan"
     branches: "!master"
     plugins:
-      - echoboomer/terraform#v1.2.12:
+      - echoboomer/terraform#v1.2.11:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
       - artifacts#v1.2.0:
@@ -96,7 +96,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: "tfplan"
-      - echoboomer/terraform#v1.2.12:
+      - echoboomer/terraform#v1.2.11:
           apply_only: true
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.10:
+      - echoboomer/terraform#v1.2.11:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
 ```
 
@@ -57,7 +57,7 @@ This is the only required parameter. You can pass in other options to adjust beh
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.10:
+      - echoboomer/terraform#v1.2.11:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           image: myrepo/mycustomtfimage
           version: 0.12.21
@@ -71,7 +71,7 @@ If you want an out of the box solution that simply executes a `plan` on non-mast
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.10:
+      - echoboomer/terraform#v1.2.11:
           apply_master: true
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
@@ -86,7 +86,7 @@ steps:
   - label: "terraform plan"
     branches: "!master"
     plugins:
-      - echoboomer/terraform#v1.2.10:
+      - echoboomer/terraform#v1.2.11:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
       - artifacts#v1.2.0:
@@ -96,7 +96,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: "tfplan"
-      - echoboomer/terraform#v1.2.10:
+      - echoboomer/terraform#v1.2.11:
           apply_only: true
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Your Terraform code is in the root of your repository in the folder `terraform/`
 
 #### Initialization
 
-It's up to you to define what flags are used for `terraform init` by taking advantage of `init_config`. This is going to vary depending on your provider(s) and/or backend(s).
+It's up to you to define what flags are used for `terraform init` by taking advantage of `init_args`. This is going to vary depending on your provider(s) and/or backend(s).
 
 #### Workspaces
 
@@ -48,7 +48,7 @@ steps:
   - label: "terraform"
     plugins:
       - echoboomer/terraform#v1.2.10:
-          init_config: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
+          init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
 ```
 
 This is the only required parameter. You can pass in other options to adjust behavior:
@@ -58,7 +58,7 @@ steps:
   - label: "terraform"
     plugins:
       - echoboomer/terraform#v1.2.10:
-          init_config: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
+          init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           image: myrepo/mycustomtfimage
           version: 0.12.21
           use_workspaces: true
@@ -73,7 +73,7 @@ steps:
     plugins:
       - echoboomer/terraform#v1.2.10:
           apply_master: true
-          init_config: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
+          init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
 ```
 
@@ -87,7 +87,7 @@ steps:
     branches: "!master"
     plugins:
       - echoboomer/terraform#v1.2.10:
-          init_config: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
+          init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
       - artifacts#v1.2.0:
           upload: "tfplan"
@@ -98,7 +98,7 @@ steps:
           download: "tfplan"
       - echoboomer/terraform#v1.2.10:
           apply_only: true
-          init_config: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
+          init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
 ```
 
@@ -122,7 +122,7 @@ If this option is supplied, `apply` will automatically run if `BUILDKITE_BRANCH`
 
 If using a custom Docker image to run `terraform`, set it here. This should only be the `repo/image` string. Set the tag in `version`. Defaults to `hashicorp/terraform`.
 
-### `init_config` (Required, array of strings)
+### `init_args` (Required, array of strings)
 
 An array of separate strings specifying flags to pass to `terraform init`. This is required. Each argument should be quoted and passed in as a separate item.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.11:
+      - echoboomer/terraform#v1.2.12:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
 ```
 
@@ -57,7 +57,7 @@ This is the only required parameter. You can pass in other options to adjust beh
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.11:
+      - echoboomer/terraform#v1.2.12:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           image: myrepo/mycustomtfimage
           version: 0.12.21
@@ -71,7 +71,7 @@ If you want an out of the box solution that simply executes a `plan` on non-mast
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.11:
+      - echoboomer/terraform#v1.2.12:
           apply_master: true
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
@@ -86,7 +86,7 @@ steps:
   - label: "terraform plan"
     branches: "!master"
     plugins:
-      - echoboomer/terraform#v1.2.11:
+      - echoboomer/terraform#v1.2.12:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
       - artifacts#v1.2.0:
@@ -96,7 +96,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: "tfplan"
-      - echoboomer/terraform#v1.2.11:
+      - echoboomer/terraform#v1.2.12:
           apply_only: true
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21

--- a/hooks/command
+++ b/hooks/command
@@ -47,7 +47,7 @@ function terraform-run() {
   local APPLY_MASTER=${BUILDKITE_PLUGIN_TERRAFORM_APPLY_MASTER:-false}
   local BUILDKITE_BRANCH=${BUILDKITE_BRANCH:-}
   local IMAGE_NAME=${BUILDKITE_PLUGIN_TERRAFORM_IMAGE:-"hashicorp/terraform"}
-  local INIT_CONFIG="${BUILDKITE_PLUGIN_TERRAFORM_INIT_CONFIG}"
+  local INIT_ARGS="${BUILDKITE_PLUGIN_TERRAFORM_INIT_ARGS}"
   local NO_VALIDATE=${BUILDKITE_PLUGIN_TERRAFORM_NO_VALIDATE:-false}
   local USE_WORKSPACES=${BUILDKITE_PLUGIN_TERRAFORM_USE_WORKSPACES:-false}
   local SKIP_APPLY_NO_DIFF=${BUILDKITE_PLUGIN_TERRAFORM_SKIP_APPLY_NO_DIFF:-false}
@@ -57,7 +57,11 @@ function terraform-run() {
   cd terraform
 
   echo "+++ :terraform: :buildkite: :hammer_and_wrench: Setting up Terraform environment..."
-  terraform-bin init "${INIT_CONFIG[@]}"
+
+  init_args=()
+  init_args+=("$BUILDKITE_PLUGIN_TERRAFORM_INIT_CONFIG")
+
+  terraform-bin init ${init_args[@]}
   echo ""
 
   if [[ "${USE_WORKSPACES}" == true ]]; then
@@ -109,3 +113,11 @@ function terraform-run() {
 }
 
 terraform-run
+
+paths=("foo" "bar")
+
+if [[ -n "${BUILDKITE_PLUGIN_CACHE_PATHS:-}" ]]; then
+  paths+=("$BUILDKITE_PLUGIN_CACHE_PATHS")
+fi
+
+echo ${paths[@]}

--- a/plugin.yml
+++ b/plugin.yml
@@ -26,4 +26,4 @@ configuration:
     workspace:
       type: string
   required:
-    - init_config
+    - init_args

--- a/plugin.yml
+++ b/plugin.yml
@@ -13,7 +13,7 @@ configuration:
       type: boolean
     image:
       type: string
-    init_config:
+    init_args:
       type: [string, array]
     no_validate:
       type: boolean


### PR DESCRIPTION
- Rename `init_config` to `init_args` because it makes more sense.
- Change refs in readme for `init_config`.
- Format list of init args into bash command for `terraform init`.