### PR TITLE
No required vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,17 @@ Add the following to your `pipeline.yml`:
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.13:
+      - echoboomer/terraform#v1.2.14:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
 ```
 
-This is the only required parameter. You can pass in other options to adjust behavior:
+While no commands are required, out of the box behavior may be undesirable without at least `init_args`.
 
 ```yml
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.13:
+      - echoboomer/terraform#v1.2.14:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           image: myrepo/mycustomtfimage
           version: 0.12.21
@@ -71,7 +71,7 @@ If you want an out of the box solution that simply executes a `plan` on non-mast
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.13:
+      - echoboomer/terraform#v1.2.14:
           apply_master: true
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
@@ -86,7 +86,7 @@ steps:
   - label: "terraform plan"
     branches: "!master"
     plugins:
-      - echoboomer/terraform#v1.2.13:
+      - echoboomer/terraform#v1.2.14:
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
       - artifacts#v1.2.0:
@@ -96,7 +96,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: "tfplan"
-      - echoboomer/terraform#v1.2.13:
+      - echoboomer/terraform#v1.2.14:
           apply_only: true
           init_args: ["-input=false", "-backend-config=bucket=my_gcp_bucket", "-backend-config=prefix=my-prefix", "-backend-config=credentials=sa.json"]
           version: 0.12.21
@@ -122,9 +122,9 @@ If this option is supplied, `apply` will automatically run if `BUILDKITE_BRANCH`
 
 If using a custom Docker image to run `terraform`, set it here. This should only be the `repo/image` string. Set the tag in `version`. Defaults to `hashicorp/terraform`.
 
-### `init_args` (Required, array)
+### `init_args` (Not Required, array)
 
-An array of separate strings specifying flags to pass to `terraform init`. This is required. Each argument should be quoted and passed in as a separate item.
+An array of separate strings specifying flags to pass to `terraform init`. Omitting it will result in no flags being passed to the `init` command.
 
 ### `no_validate` (Not Required, boolean)
 

--- a/hooks/command
+++ b/hooks/command
@@ -47,7 +47,7 @@ function terraform-run() {
   local APPLY_MASTER=${BUILDKITE_PLUGIN_TERRAFORM_APPLY_MASTER:-false}
   local BUILDKITE_BRANCH=${BUILDKITE_BRANCH:-}
   local IMAGE_NAME=${BUILDKITE_PLUGIN_TERRAFORM_IMAGE:-"hashicorp/terraform"}
-  local INIT_ARGS="${BUILDKITE_PLUGIN_TERRAFORM_INIT_ARGS}"
+  local INIT_ARGS="${BUILDKITE_PLUGIN_TERRAFORM_INIT_ARGS:-}"
   local NO_VALIDATE=${BUILDKITE_PLUGIN_TERRAFORM_NO_VALIDATE:-false}
   local USE_WORKSPACES=${BUILDKITE_PLUGIN_TERRAFORM_USE_WORKSPACES:-false}
   local SKIP_APPLY_NO_DIFF=${BUILDKITE_PLUGIN_TERRAFORM_SKIP_APPLY_NO_DIFF:-false}
@@ -59,7 +59,7 @@ function terraform-run() {
   echo "+++ :terraform: :buildkite: :hammer_and_wrench: Setting up Terraform environment..."
 
   init_args=()
-  init_args+=("$BUILDKITE_PLUGIN_TERRAFORM_INIT_ARGS")
+  init_args+=("$INIT_ARGS")
 
   terraform-bin init ${init_args[@]}
   echo ""

--- a/plugin.yml
+++ b/plugin.yml
@@ -25,5 +25,3 @@ configuration:
       type: string
     workspace:
       type: string
-  required:
-    - init_args


### PR DESCRIPTION
- No longer requires any parameters since `init_args` will be optional. We just don't do anything with `init` beyond running it if no args are provided. This might work fine depending on local Terraform config.
- Fix parsing of args if they're used.