### PR TITLE
Add debug option for showing Docker command string.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Add the following to your `pipeline.yml`:
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.19:
+      - echoboomer/terraform#v1.2.20:
           init_args:
             - "-input=false"
             - "-backend-config=bucket=my_gcp_bucket"
@@ -61,7 +61,7 @@ While no commands are required, out of the box behavior may be undesirable witho
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.19:
+      - echoboomer/terraform#v1.2.20:
           init_args:
             - "-input=false"
             - "-backend-config=bucket=my_gcp_bucket"
@@ -79,7 +79,7 @@ To pass in extra environment variables to the Docker container:
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.19:
+      - echoboomer/terraform#v1.2.20:
           env:
             - "FOO=foo"
             - "BAR=baz"
@@ -100,7 +100,7 @@ If you want an out of the box solution that simply executes a `plan` on non-mast
 steps:
   - label: "terraform"
     plugins:
-      - echoboomer/terraform#v1.2.19:
+      - echoboomer/terraform#v1.2.20:
           apply_master: true
           init_args:
             - "-input=false"
@@ -119,7 +119,7 @@ steps:
   - label: "terraform plan"
     branches: "!master"
     plugins:
-      - echoboomer/terraform#v1.2.19:
+      - echoboomer/terraform#v1.2.20:
           init_args:
             - "-input=false"
             - "-backend-config=bucket=my_gcp_bucket"
@@ -133,7 +133,7 @@ steps:
     plugins:
       - artifacts#v1.2.0:
           download: "tfplan"
-      - echoboomer/terraform#v1.2.19:
+      - echoboomer/terraform#v1.2.20:
           apply_only: true
           init_args:
             - "-input=false"

--- a/hooks/command
+++ b/hooks/command
@@ -80,6 +80,11 @@ function terraform-bin() {
     "${@}"
   )
 
+  if [[ "${DEBUG}" == true ]]; then
+    echo "--- :terraform: :buildkite: :hammer_and_wrench: Debug on - show Docker command string."
+    echo "docker run $(printf "%q " "${docker_args[@]}")"
+  fi
+
   docker run $(printf "%q " "${docker_args[@]}")
 }
 


### PR DESCRIPTION
If `debug` is enabled, show Docker command string.