### PR TITLE
Add precommand hook/parameter

### DIFF
--- a/hooks/pre-command
+++ b/hooks/pre-command
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# if a pre-command has been specified, run it now
+PRECOMMAND=${BUILDKITE_PLUGIN_TERRAFORM_PRECOMMAND:-false}
+
+if [ "$PRECOMMAND" != "false" ]; then
+    if [ -f "$PRECOMMAND" ]; then
+        # if it's a file, then just source it
+        source $PRECOMMAND
+    else
+        # otherwise, attempt to execute it directly
+        eval $PRECOMMAND
+    fi
+fi

--- a/plugin.yml
+++ b/plugin.yml
@@ -29,3 +29,5 @@ configuration:
       type: string
     workspace:
       type: string
+    precommand:
+      type: string


### PR DESCRIPTION
Adds the ability to specify a pre-command script that will run before the main terraform plugin runs. This could be useful for downloading credentials or other setup steps before running terraform.