### PR TITLE
Get workspace value from Buildkite Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,13 @@ Additional volume mount statements to provide to the Docker container in the for
 
 If setting `use_workspaces` to `true`, pass in the Terraform workspace name here.
 
+### `workspace_metadata_key` (Not Required, string)
+
+If setting `use_workspaces` to `true`, pass in a [Buildkite metadata](https://buildkite.com/docs/pipelines/build-meta-data) 
+key and the plugin will set the Terraform workspace based on the metadata value. 
+
+Note: If `workspace` is also set it will be overridden.   
+
 ## Developing
 
 To run the linting tool:

--- a/hooks/command
+++ b/hooks/command
@@ -110,6 +110,7 @@ function terraform-run() {
   local VERSION=${BUILDKITE_PLUGIN_TERRAFORM_VERSION:-0.13.0}
   local WORKSPACE=${BUILDKITE_PLUGIN_TERRAFORM_WORKSPACE:-default}
   local AUTO_CREATE_WORKSPACE=${BUILDKITE_PLUGIN_TERRAFORM_AUTO_CREATE_WORKSPACE:-true}
+  local WORKSPACE_METADATA_KEY=${BUILDKITE_PLUGIN_TERRAFORM_WORKSPACE_METADATA_KEY:-}
 
   # Set arguments for terraform init.
   args=()
@@ -131,6 +132,7 @@ function terraform-run() {
     echo "VERSION: ${VERSION}"
     echo "WORKSPACE: ${WORKSPACE}"
     echo "AUTO_CREATE_WORKSPACE: ${AUTO_CREATE_WORKSPACE}"
+    echo "WORKSPACE_METADATA_KEY ${WORKSPACE_METADATA_KEY}"
   fi
 
   cd terraform
@@ -144,6 +146,10 @@ function terraform-run() {
   echo ""
 
   if [[ "${USE_WORKSPACES}" == true ]]; then
+    if [[ -n ${WORKSPACE_METADATA_KEY} ]]; then
+      WORKSPACE=$(buildkite-agent meta-data get "${WORKSPACE_METADATA_KEY}")
+      echo "Overrode WORKSPACE with metadata key: ${WORKSPACE_METADATA_KEY}. Set WORKSPACE=${WORKSPACE}"
+    fi;
     if [[ "${AUTO_CREATE_WORKSPACE}" == true ]]; then
       terraform-bin workspace select ${WORKSPACE} || terraform-bin workspace new ${WORKSPACE}
     else

--- a/plugin.yml
+++ b/plugin.yml
@@ -35,3 +35,5 @@ configuration:
       type: [string, array]
     workspace:
       type: string
+    workspace_metadata_key:
+      type: string


### PR DESCRIPTION
A use case surfaced where we wanted to get the workspace from a Buildkite `input` step.  An input step sets metadata for fields. 

This PR allows for the terraform plugin to set the workspace from the Buildkite metadata collected in an input step.