### PR TITLE
Fixes condition where APPLY_ONLY fails since TF_DIFF isn't set.

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -149,7 +149,7 @@ function terraform-run() {
     if [[ -n ${WORKSPACE_METADATA_KEY} ]]; then
       WORKSPACE=$(buildkite-agent meta-data get "${WORKSPACE_METADATA_KEY}")
       echo "Overrode WORKSPACE with metadata key: ${WORKSPACE_METADATA_KEY}. Set WORKSPACE=${WORKSPACE}"
-    fi;
+    fi
     if [[ "${AUTO_CREATE_WORKSPACE}" == true ]]; then
       terraform-bin workspace select ${WORKSPACE} || terraform-bin workspace new ${WORKSPACE}
     else
@@ -189,6 +189,8 @@ function terraform-run() {
 
     echo "--- :terraform: :buildkite: :floppy_disk: Listing directory contents for record keeping."
     ls -al .
+  else
+    export TF_DIFF=true
   fi
 
   if [[ "${APPLY}" == true || "${APPLY_ONLY}" == true || ("${APPLY_MASTER}" == true && "${BUILDKITE_BRANCH}" == "master") ]]; then


### PR DESCRIPTION
Indicated in: https://github.com/echoboomer/terraform-buildkite-plugin/issues/25

There exists a condition where if using `APPLY_ONLY=true`, `TF_DIFF` is unset and causes an issue. This just implicitly sets it to `true` so the functionality is maintained.