### PR TITLE
Ensure entrypoint is set to terraform

### DIFF
--- a/hooks/command
+++ b/hooks/command
@@ -59,6 +59,7 @@ function terraform-bin() {
   docker_args+=(
     "--rm"
     "-it"
+    "--entrypoint" "terraform"
     "-e" "SSH_AUTH_SOCK"
     "-v" "$SSH_AUTH_SOCK:$SSH_AUTH_SOCK"
     "-v" "$PWD:/svc"


### PR DESCRIPTION
Addresses #30.

We want to change the docker image to one with a different entrypoint, but for this plugin the entrypoint has to be terraform. This PR ensures the entrypoint will be overridden so it is always terraform. 