### PR TITLE
Add `working_directory` parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The plugin makes a few assumptions about your environment:
 
 #### Organization
 
-Your Terraform code is in the root of your repository in the folder `terraform/`. At this time, another location is not supported.
+Your Terraform code is assumed to be in the root of your repository in the folder `terraform/`, but this can be overridden with the `working_directory` parameter.
 
 #### Initialization
 
@@ -211,16 +211,20 @@ Which version of Terraform to use. Defaults to `0.13.0`. This is the tag applied
 
 Additional volume mount statements to provide to the Docker container in the form `foo:bar`. Uses `-v` on the backend.
 
+### `working_directory` (Not Required, string)
+
+Directory in which the terraform code is located. Defaults to `terraform`.
+
 ### `workspace` (Not Required, string)
 
 If setting `use_workspaces` to `true`, pass in the Terraform workspace name here.
 
 ### `workspace_metadata_key` (Not Required, string)
 
-If setting `use_workspaces` to `true`, pass in a [Buildkite metadata](https://buildkite.com/docs/pipelines/build-meta-data) 
-key and the plugin will set the Terraform workspace based on the metadata value. 
+If setting `use_workspaces` to `true`, pass in a [Buildkite metadata](https://buildkite.com/docs/pipelines/build-meta-data)
+key and the plugin will set the Terraform workspace based on the metadata value.
 
-Note: If `workspace` is also set it will be overridden.   
+Note: If `workspace` is also set it will be overridden.
 
 ## Developing
 

--- a/hooks/command
+++ b/hooks/command
@@ -7,8 +7,10 @@ set -euo pipefail
 #########
 
 # Check for presence of required directories.
+WORKING_DIRECTORY=${BUILDKITE_PLUGIN_TERRAFORM_WORKING_DIRECTORY:-"terraform"}
+
 required_folders=(
-  terraform
+  ${WORKING_DIRECTORY}
 )
 
 for dir in "${required_folders[@]}"; do
@@ -137,7 +139,7 @@ function terraform-run() {
     echo "WORKSPACE_METADATA_KEY ${WORKSPACE_METADATA_KEY}"
   fi
 
-  cd terraform
+  cd ${WORKING_DIRECTORY}
 
   echo "+++ :terraform: :buildkite: :hammer_and_wrench: Setting up Terraform environment..."
   if [[ "${DEBUG}" == true ]]; then

--- a/plugin.yml
+++ b/plugin.yml
@@ -37,6 +37,8 @@ configuration:
       type: string
     volumes:
       type: [string, array]
+    working_directory:
+      type: string
     workspace:
       type: string
     workspace_metadata_key:


### PR DESCRIPTION
Hello @echoboomer, we meet again 👋 

This allows the terraform code to reside somewhere other than the default `terraform/`.

This commit includes a bit of excess whitespace trimming, also.

Running the tests gives me a warning, but same happens on master, and the command overall exits with 0. Maybe it's because I'm running the test on Mac OS?

```
$ docker-compose run --rm tests
...
The following warnings were encountered during tests:
BW01: `run`'s command `/plugin/hooks/command` exited with code 127, indicating 'Command not found'. Use run's return code checks, e.g. `run -127`, to fix this message.
      (from function `run' in file /opt/bats/lib/bats-core/test_functions.bash, line 299,
       in test file tests/command.bats, line 275)
```
